### PR TITLE
fix: support Next.js

### DIFF
--- a/apps/enrolla-server/src/configurations/configuration-managers/impl/sdk.configuration-manager.ts
+++ b/apps/enrolla-server/src/configurations/configuration-managers/impl/sdk.configuration-manager.ts
@@ -8,7 +8,6 @@ export class SdkConfigurationManager implements ConfigurationManager {
   private readonly logger = new Logger(SdkConfigurationManager.name);
 
   DEFAULT_POLLING_INTERVAL_SECONDS = 10;
-  private sdkInitialized = false;
   private url = env.SDK_ENROLLA_SERVER_GRAPHQL_ENDPOINT;
   private apiToken = env.SDK_API_TOKEN;
   private pollingEnabled = env.SDK_POLLING_ENABLED
@@ -19,10 +18,6 @@ export class SdkConfigurationManager implements ConfigurationManager {
     : this.DEFAULT_POLLING_INTERVAL_SECONDS;
 
   async initialize() {
-    if (this.sdkInitialized) {
-      return;
-    }
-
     try {
       await sdk.initialize({
         url: this.url,
@@ -33,8 +28,6 @@ export class SdkConfigurationManager implements ConfigurationManager {
           onError: (error) => this.logger.error('onPollingError', error),
         },
       });
-
-      this.sdkInitialized = true;
     } catch (err) {
       this.logger.error('SDK Initiation Failed', err);
       throw err;

--- a/docs/sdk/node.mdx
+++ b/docs/sdk/node.mdx
@@ -27,22 +27,51 @@ Initialize the SDK in the entry point of your application before accepting conne
 
 <Warning>Forgetting to initialize the SDK will result in an exception being thrown.</Warning>
 
-#### Example (Express Server)
-```ts
-import express from 'express'
-import enrolla from '@enrolla/node-server-sdk'
+#### Examples
 
-const app = express()
-const port = 3000
+<Tabs>
+  <Tab title="Express">
+    ```ts
+    import express from 'express'
+    import * as enrolla from '@enrolla/node-server-sdk'
 
-try {
-  enrolla.initialize({ apiToken: <API_TOKEN> });
-} catch (error) { // handle error }
+    const app = express()
+    const port = 3000
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
-})
-```
+    try {
+      await enrolla.initialize({ apiToken: <API_TOKEN> });
+    } catch (error) // handle error
+
+    app.listen(port, () => {
+      console.log(`Example app listening on port ${port}`)
+    })
+    ```
+  </Tab>
+  <Tab title="Next.js">
+    ```ts
+    import type { NextApiRequest, NextApiResponse } from "next";
+    import * as enrolla from "@enrolla/node-server-sdk";
+
+    type Data = {
+      ...
+    };
+
+    export default async function handler(
+      req: NextApiRequest,
+      res: NextApiResponse<Data>
+    ) {
+      // Unfortunately, Next.js doesn't support server-side initialization
+      // Since the SDK will actually be initialized only once, 
+      // it's safe to call this function multiple times
+      await enrolla.initialize({
+        apiToken: process.env.ENROLLA_API_TOKEN!,
+      });
+      // You can start using Enrolla SDK here
+      ...
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## Feature Evaluation
 

--- a/libs/graphql-codegen/package.json
+++ b/libs/graphql-codegen/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@enrolla/graphql-codegen",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/libs/node-server-sdk/package.json
+++ b/libs/node-server-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enrolla/node-server-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/enrolla/enrolla.git",

--- a/libs/node-server-sdk/src/lib/configuration/index.ts
+++ b/libs/node-server-sdk/src/lib/configuration/index.ts
@@ -26,6 +26,10 @@ const startPolling = (configuration: InitializeOptions) => {
  * @throws {InitializationError} if the configuration is invalid or if failed to fetch feature data.
  */
 export const initialize = async (options: InitializeOptions) => {
+  if (_configuration) {
+    return;
+  }
+
   validateConfiguration(options);
   _configuration = Object.freeze(options);
 


### PR DESCRIPTION
In Next.js, there isn't a way to call a function on server-side initialization. Thus, we're forced to call the SDK `initialize` function in every API call. 

I've changed the SDK to support that so initialization will always happen only once in the lifetime of a program.